### PR TITLE
Fixes DivideByZeroError if no significant terms

### DIFF
--- a/FUNC-E.py
+++ b/FUNC-E.py
@@ -448,8 +448,14 @@ if __name__ == "__main__":
 
         # Apply multiple testing correction using Bonferroni and Benjamini-Hochberg
         # on a per-module basis.
-        bonferroni = sm.multipletests(modResults["Fishers pVal"], method='bonferroni')
-        benjamini = sm.multipletests(modResults["Fishers pVal"], method='fdr_bh')
+        bonferroni = [None, None]       # Default length-two list for scope
+        benjamini = [None, None]
+        if len(modResults["Fishers pVal"]) > 0:     # some terms are significant by ecut standard
+            bonferroni = sm.multipletests(modResults["Fishers pVal"], method='bonferroni')
+            benjamini = sm.multipletests(modResults["Fishers pVal"], method='fdr_bh')
+        else:
+            bonferroni = ["Not enough significant terms", "Not enough significant terms"]   # message in result if insufficient terms
+            benjamini = ["Not enough significant terms", "Not enough significant terms"]
         modResults['Bonferroni'] = bonferroni[1]
         modResults['Benjamini'] = benjamini[1]
         results = results.append(modResults, ignore_index=True, sort=False)


### PR DESCRIPTION
Reed Bender from Dr. Feltus's lab was running into a pesky divide by zero error in these lines, and this should fix the problem. Instead of throwing an error, it still writes the results to a file so other values can be viewed, but shows an "Error" for the values that couldn't be calculated. The description I emailed to him is below:

So for reference to start, I had to set ecut all the way to 1 (aka totally useless) for it not to throw that error. In this error case we're looking at, the module in question ("TCGA-LUSC") has only [one unique vocabulary](https://github.com/SystemsGenetics/FUNC-E/blob/develop/FUNC-E.py#L433): "Lung_Biomarkers", [which has three terms](https://github.com/SystemsGenetics/FUNC-E/blob/develop/FUNC-E.py#L436) "LUAD_RELLI_DIAGNOSTIC_15", "LUSC_RELLI_DIAGNOSTIC_33", and "NODIAG_RELLI_21". [FUNC-E then calculates a p-value for each of the terms in the module and its various counts](https://github.com/SystemsGenetics/FUNC-E/blob/develop/FUNC-E.py#L437). For these three terms, the p-values are calculated to be as follows:

LUAD_RELLI_DIAGNOSTIC_15   --   0.646727153693444
LUSC_RELLI_DIAGNOSTIC_33   --   0.5919686288066827
NODIAG_RELLI_21   --   0.5799937403139382

After each is calculated, they're [compared with the e-cut threshold to see if they should be saved into the ModResults](https://github.com/SystemsGenetics/FUNC-E/blob/develop/FUNC-E.py#L440-L442) (so your ecut would have to be at least 0.58 to capture any of them). However, with an ecut below that, since none would be saved in the ModResults, we run into an issue calculating bonferroni. That being the case, ModResults["Fishers pVal"] is just an empty list, [so our list of p-vals passed to this function is an empty list](https://github.com/SystemsGenetics/FUNC-E/blob/develop/FUNC-E.py#L451). When the stats module makes a calculation where it tries to divide by the length of it's input list, we get our error.